### PR TITLE
refine server routing utilities for clarity

### DIFF
--- a/server/routes/deploy.js
+++ b/server/routes/deploy.js
@@ -24,12 +24,15 @@ router.post('/webhook', async (req, res) => {
     if (!verifyGithubSignature(WEBHOOK_SECRET, req.rawBody, sig)) {
       return res.status(401).json({ error: 'Invalid signature' });
     }
-    if (event !== 'push') return res.json({ ok: true, ignored: true, reason: 'not a push event' });
+    if (event !== 'push') {
+      return res.json({ ok: true, ignored: true, reason: 'not a push event' });
+    }
 
-    const payload = req.body || {};
-    const ref = payload.ref;
+    const { ref = '' } = req.body || {};
     const expectedRef = `refs/heads/${DEPLOY_BRANCH}`;
-    if (ref !== expectedRef) return res.json({ ok: true, ignored: true, reason: `ref ${ref} != ${expectedRef}` });
+    if (ref !== expectedRef) {
+      return res.json({ ok: true, ignored: true, reason: `ref ${ref} != ${expectedRef}` });
+    }
 
     res.status(202).json({ ok: true, action: 'deploy-started', branch: DEPLOY_BRANCH });
     setImmediate(async () => {

--- a/server/routes/files.js
+++ b/server/routes/files.js
@@ -12,17 +12,22 @@ const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD;
 
 const router = express.Router();
 
+function formatFile(item) {
+  const { deleteHash, ...rest } = item;
+  return {
+    ...rest,
+    requiresPassword: Boolean(deleteHash),
+    url: `/uploads/${rest.filename}`,
+    downloadUrl: `/d/${rest.id}`,
+  };
+}
+
 router.get('/api/files', (_req, res) => {
   const manifest = loadManifest();
   const files = manifest.files
     .slice()
     .sort((a, b) => b.uploadedAt.localeCompare(a.uploadedAt))
-    .map(({ deleteHash, ...rest }) => ({
-      ...rest,
-      requiresPassword: !!deleteHash,
-      url: `/uploads/${rest.filename}`,
-      downloadUrl: `/d/${rest.id}`,
-    }));
+    .map(formatFile);
   res.json({ files });
 });
 
@@ -31,10 +36,7 @@ router.get('/api/files/:id', (req, res) => {
   const manifest = loadManifest();
   const item = manifest.files.find(f => f.id === id);
   if (!item) return res.status(404).json({ error: 'Not found' });
-  const { deleteHash, ...rest } = item;
-  return res.json({
-    file: { ...rest, requiresPassword: !!deleteHash, url: `/uploads/${rest.filename}`, downloadUrl: `/d/${rest.id}` }
-  });
+  return res.json({ file: formatFile(item) });
 });
 
 router.get('/d/:id', (req, res) => {

--- a/server/routes/upload.js
+++ b/server/routes/upload.js
@@ -27,32 +27,34 @@ const storage = multer.diskStorage({
 const upload = multer({ storage, limits: { files: 1, fileSize: MAX_FILE_SIZE_BYTES } });
 
 async function verifyTurnstileToken(token, ip) {
+  if (!TURNSTILE_SECRET || !token) return false;
   try {
-    if (!TURNSTILE_SECRET) return false;
-    if (!token) return false;
-    const body = new URLSearchParams();
-    body.append('secret', TURNSTILE_SECRET);
-    body.append('response', token);
+    const body = new URLSearchParams({ secret: TURNSTILE_SECRET, response: token });
     if (ip) body.append('remoteip', ip);
-    const r = await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', { method: 'POST', body });
-    const js = await r.json().catch(() => ({}));
-    return Boolean(js.success);
-  } catch { return false; }
+    const res = await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
+      method: 'POST',
+      body,
+    });
+    const data = await res.json();
+    return Boolean(data.success);
+  } catch {
+    return false;
+  }
 }
 
 const router = express.Router();
 
 router.post('/api/upload', upload.single('file'), async (req, res) => {
-  const cleanupOnAbort = () => { try { if (req._tempPath) fs.unlinkSync(req._tempPath); } catch {} };
-  req.on('aborted', cleanupOnAbort);
-  req.on('close', () => { if (!res.headersSent) cleanupOnAbort(); });
+  const removeTempFile = () => { try { if (req._tempPath) fs.unlinkSync(req._tempPath); } catch {} };
+  req.on('aborted', removeTempFile);
+  req.on('close', () => { if (!res.headersSent) removeTempFile(); });
 
   try {
     if (!req.file) return res.status(400).json({ error: 'No file uploaded' });
 
     const token = (req.body && (req.body['cf-turnstile-response'] || req.body.turnstileToken)) || '';
     const ok = await verifyTurnstileToken(token, req.ip);
-    if (!ok) { cleanupOnAbort(); return res.status(403).json({ error: 'Captcha verification failed' }); }
+    if (!ok) { removeTempFile(); return res.status(403).json({ error: 'Captcha verification failed' }); }
 
     const { originalname, mimetype, size } = req.file;
     const id = req._uploadId || path.parse(req.file.filename).name;
@@ -60,8 +62,12 @@ router.post('/api/upload', upload.single('file'), async (req, res) => {
     const finalName = `${id}${ext}`;
     const finalPath = path.join(UPLOAD_DIR, finalName);
 
-    try { fs.renameSync(req._tempPath || req.file.path, finalPath); }
-    catch (e) { try { fs.unlinkSync(req._tempPath || req.file.path); } catch {} ; throw e; }
+    try {
+      fs.renameSync(req._tempPath || req.file.path, finalPath);
+    } catch (e) {
+      try { fs.unlinkSync(req._tempPath || req.file.path); } catch {}
+      throw e;
+    }
 
     const now = new Date().toISOString();
     let deleteHash = null;

--- a/server/utils/deploy.js
+++ b/server/utils/deploy.js
@@ -24,11 +24,11 @@ export async function runDeploy({ GIT_CMD, REPO_DIR, DEPLOY_BRANCH, DEPLOY_INSTA
     await execAsync(installCmd, { cwd, env });
   }
 
-    if (PM2_PROCESS) {
-        console.log(`[deploy] starting pm2 process: ${PM2_PROCESS}`);
-        await execAsync(`${PM2_CMD} start server/index.js --name ${PM2_PROCESS}`, { cwd, env });
-    } else {
-        console.warn('[deploy] PM2_PROCESS is not set; falling back to process exit for PM2 auto-restart');
-        setTimeout(() => process.exit(0), 500);
-    }
+  if (PM2_PROCESS) {
+    console.log(`[deploy] starting pm2 process: ${PM2_PROCESS}`);
+    await execAsync(`${PM2_CMD} start server/index.js --name ${PM2_PROCESS}`, { cwd, env });
+  } else {
+    console.warn('[deploy] PM2_PROCESS is not set; falling back to process exit for PM2 auto-restart');
+    setTimeout(() => process.exit(0), 500);
+  }
 }

--- a/server/utils/manifest.js
+++ b/server/utils/manifest.js
@@ -10,20 +10,27 @@ export const UPLOAD_DIR = path.join(ROOT, '..', 'uploads');
 export const DATA_DIR = path.join(ROOT, '..', 'data');
 export const MANIFEST_PATH = path.join(DATA_DIR, 'manifest.json');
 
-export function ensureDirs(){
+export function ensureDirs() {
   if (!fs.existsSync(UPLOAD_DIR)) fs.mkdirSync(UPLOAD_DIR, { recursive: true });
   if (!fs.existsSync(DATA_DIR)) fs.mkdirSync(DATA_DIR, { recursive: true });
-  if (!fs.existsSync(MANIFEST_PATH)) fs.writeFileSync(MANIFEST_PATH, JSON.stringify({ files: [] }, null, 2));
+  if (!fs.existsSync(MANIFEST_PATH)) {
+    fs.writeFileSync(MANIFEST_PATH, JSON.stringify({ files: [] }, null, 2));
+  }
   for (const f of fs.readdirSync(UPLOAD_DIR)) {
-    if (f.endsWith('.part')) { try { fs.unlinkSync(path.join(UPLOAD_DIR, f)); } catch {} }
+    if (f.endsWith('.part')) {
+      try { fs.unlinkSync(path.join(UPLOAD_DIR, f)); } catch {}
+    }
   }
 }
 
-export function loadManifest(){
-  try { return JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf8')); }
-  catch { return { files: [] }; }
+export function loadManifest() {
+  try {
+    return JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf8'));
+  } catch {
+    return { files: [] };
+  }
 }
 
-export function saveManifest(manifest){
+export function saveManifest(manifest) {
   fs.writeFileSync(MANIFEST_PATH, JSON.stringify(manifest, null, 2));
 }

--- a/server/utils/verifyGithub.js
+++ b/server/utils/verifyGithub.js
@@ -1,13 +1,14 @@
 import crypto from 'crypto';
-export function verifyGithubSignature(secret, rawBody, sigHeader){
+
+export function verifyGithubSignature(secret, rawBody, sigHeader) {
+  if (!secret || !sigHeader?.startsWith('sha256=')) return false;
   try {
-    if (!secret) return false;
-    if (!sigHeader || !sigHeader.startsWith('sha256=')) return false;
     const theirSig = Buffer.from(sigHeader.slice('sha256='.length), 'hex');
     const hmac = crypto.createHmac('sha256', secret);
     hmac.update(rawBody || Buffer.alloc(0));
     const digest = Buffer.from(hmac.digest('hex'), 'hex');
-    if (theirSig.length !== digest.length) return false;
-    return crypto.timingSafeEqual(theirSig, digest);
-  } catch { return false; }
+    return theirSig.length === digest.length && crypto.timingSafeEqual(theirSig, digest);
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
## Summary
- improve upload route Turnstile verification and temporary-file cleanup
- centralize file metadata formatting in file routes
- tidy deploy and manifest utilities and add newline consistency

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b98cf8ead48331b349dad9a85fae3d